### PR TITLE
fix arch linux package link

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
         <h3 id="arch-linux">Arch Linux</h3>
         <small>
           <a
-            href="https://archlinux.org/packages/community/x86_64/editorconfig-checker/"
+            href="https://archlinux.org/packages/extra/x86_64/editorconfig-checker/"
             rel="noopener noreferrer"
             target="_blank"
             >package</a


### PR DESCRIPTION
The `community` repo got merged into the `extra` repo.