### PR TITLE
Update configuration file name in documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,11 +267,11 @@ makepkg -si</pre
         <p>
           There are a bunch of command line flags you can use, but there is also
           a configuration file which you can use in your current working
-          directory called <code>.editorconfig-checker.json</code>. If you want
-          to use a different config you can pass the
-          <code>-config &lt;path&gt;</code>-flag to the binary. You can generate
-          a configuration with the <code>init</code>-flag. A sample
-          configuration file can look like this:
+          directory called <code>.editorconfig-checker.json</code> or 
+          <code>.ecrc</code> (deprecated). If you want to use a different config
+          you can pass the <code>-config &lt;path&gt;</code>-flag to the binary.
+          You can generate a configuration with the <code>init</code>-flag. A
+          sample configuration file can look like this:
         </p>
         <pre>
 {

--- a/index.html
+++ b/index.html
@@ -267,10 +267,11 @@ makepkg -si</pre
         <p>
           There are a bunch of command line flags you can use, but there is also
           a configuration file which you can use in your current working
-          directory called <code>.ecrc</code>. If you want to use a different
-          config you can pass the <code>-config &lt;path&gt;</code>-flag to the
-          binary. You can generate a configuration with the <code>init</code>
-          -flag. A sample configuration file can look like this:
+          directory called <code>.editorconfig-checker.json</code>. If you want
+          to use a different config you can pass the
+          <code>-config &lt;path&gt;</code>-flag to the binary. You can generate
+          a configuration with the <code>init</code>-flag. A sample
+          configuration file can look like this:
         </p>
         <pre>
 {


### PR DESCRIPTION
Update the config file name from `.ecrc` to `.editorconfig-checker.json`.

https://github.com/editorconfig-checker/editorconfig-checker?tab=readme-ov-file#configuration