### PR TITLE
Fix typo in GitHub Organization name

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@ makepkg -si</pre
             href="https://github.com/editorconfig-checker/editorconfig-checker"
             rel="noopener noreferrer"
             target="_blank"
-            >editorconfig-cheker/editorconfig-checker</a
+            >editorconfig-checker/editorconfig-checker</a
           >. If you have issues for a specific language client, which are in
           fact only wrappers of the main binary, you can of course open an issue
           there - and don't worry, if you use the wrong repository it is not a


### PR DESCRIPTION
`editorconfig-cheker/editorconfig-checker`
:arrow_down: 
`editorconfig-checker/editorconfig-checker`